### PR TITLE
Get rid of Ext warnings on console

### DIFF
--- a/app/Application.js
+++ b/app/Application.js
@@ -29,6 +29,10 @@ Ext.define('momo.Application', {
         var moduleUtil = momo.util.Module;
         var urlUtil = momo.util.URL;
 
+        // disable annoying debug messages from WAI-ARIA 1.0 recommendations.
+        Ext.enableAriaButtons = false;
+        Ext.enableAriaPanels = false;
+
         // get the current application ID
         var appId = urlUtil.getUrlQueryParameter('id');
 

--- a/classic/src/view/component/Map.js
+++ b/classic/src/view/component/Map.js
@@ -4,7 +4,7 @@
  */
 Ext.define('momo.view.component.Map', {
     extend: 'GeoExt.component.Map',
-    xtype: 'shogun-component-map',
+    xtype: 'momo-component-map',
 
     requires: [
         'BasiGX.util.ConfigParser',
@@ -20,7 +20,7 @@ Ext.define('momo.view.component.Map', {
 
     inheritableStatics: {
         guess: function(){
-            return Ext.ComponentQuery.query('shogun-component-map')[0];
+            return Ext.ComponentQuery.query('momo-component-map')[0];
         }
     },
 

--- a/classic/src/view/container/Viewport.js
+++ b/classic/src/view/container/Viewport.js
@@ -1,6 +1,12 @@
 Ext.define('momo.view.container.Viewport', {
     extend: 'Ext.container.Viewport',
 
+    requires: [
+               'BasiGX.*',
+               'GeoExt.*',
+               'momo.*'
+           ],
+
     initComponent: function() {
         var me = this;
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 
-    <title>ShogunClient</title>
+    <title>Momo Map-Client</title>
 
     <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
     <script src="http://openlayers.org/en/master/build/ol.js"></script>
@@ -46,8 +46,8 @@
             //};
         };
     </script>
-    
-    
+
+
     <!-- The line below must be kept intact for Sencha Cmd to build your application -->
     <script id="microloader" data-app="dc734eb3-a085-4750-8ad2-fc3743a7ec31" type="text/javascript" src="bootstrap.js"></script>
 

--- a/resources/appContext.json
+++ b/resources/appContext.json
@@ -55,7 +55,7 @@
                     },
                     {
                         "title": "Center Region",
-                        "xtype": "shogun-component-map"
+                        "xtype": "momo-component-map"
                     }
                 ]
             },


### PR DESCRIPTION
With this MR some (annoying) ext-debug log messages on console will be avoided/fixed.

Also xtype of `momo.view.Component.Map` class was changed to match momo-workspace.
