### PR TITLE
Tests and eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ packages/
 sass/
 bootstrap.js
 ci/
+lib/

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
         "window": false,
         "location": false,
         "BasiGX": true,
-        "ShogunClient": true,
+        "momo": true,
 
         "afterEach": false,
         "beforeEach": false,

--- a/app.json
+++ b/app.json
@@ -85,11 +85,11 @@
     "sass": {
         /**
          * The root namespace to use when mapping *.scss files to classes in the
-         * sass/src and sass/var directories. For example, "ShogunClient.view.Foo" would
-         * map to "sass/src/view/Foo.scss". If we changed this to "ShogunClient.view" then
+         * sass/src and sass/var directories. For example, "momo.view.Foo" would
+         * map to "sass/src/view/Foo.scss". If we changed this to "momo.view" then
          * it would map to "sass/src/Foo.scss". To style classes outside the app's
          * root namespace, change this to "". Doing so would change the mapping of
-         * "ShogunClient.view.Foo" to "sass/src/ShogunClient/view/Foo.scss".
+         * "momo.view.Foo" to "sass/src/momo/view/Foo.scss".
          */
         "namespace": "momo",
 

--- a/classic/sass/src/Readme.md
+++ b/classic/sass/src/Readme.md
@@ -2,9 +2,9 @@
 
 This folder contains Sass files defining CSS rules corresponding to classes
 included in the application's JavaScript code build when using the classic toolkit.
-By default, files in this folder are mapped to the application's root namespace, 'ShogunClient'.
+By default, files in this folder are mapped to the application's root namespace, 'momo'.
 This is set in `"app.json"`:
 
     "sass": {
-        "namespace": "ShogunClient"
+        "namespace": "momo"
     }

--- a/classic/sass/var/Readme.md
+++ b/classic/sass/var/Readme.md
@@ -3,4 +3,4 @@
 This folder contains Sass files defining Sass variables corresponding to classes
 included in the application's JavaScript code build when using the classic toolkit.
 By default, files in this folder are mapped to the application's root namespace,
-'ShogunClient' in the same way as `"ShogunClient/sass/src"`.
+'momo' in the same way as `"momo/sass/src"`.

--- a/resources/Readme.md
+++ b/resources/Readme.md
@@ -1,4 +1,4 @@
-# ShogunClient/resources
+# momo/resources
 
 This folder contains resources (such as images) needed by the application. This file can
 be removed if not needed.

--- a/sass/Readme.md
+++ b/sass/Readme.md
@@ -14,20 +14,20 @@ This folder contains misc. support code for Sass builds (global functions, etc.)
 ### ./sass/src
 
 This folder contains Sass files defining CSS rules corresponding to classes
-included in the application's JavaScript code build. By default, files in this 
-folder are mapped to the application's root namespace, 'ShogunClient'. This is set in
+included in the application's JavaScript code build. By default, files in this
+folder are mapped to the application's root namespace, 'momo'. This is set in
 `"app.json"`:
 
     "sass": {
-        "namespace": "ShogunClient"
+        "namespace": "momo"
     }
 
 ### ./sass/var
 
 This folder contains Sass files defining Sass variables corresponding to classes
-included in the application's JavaScript code build. By default, files in this 
-folder are mapped to the application's root namespace, 'ShogunClient' in the same way
-as `"ShogunClient/sass/src"`.
+included in the application's JavaScript code build. By default, files in this
+folder are mapped to the application's root namespace, 'momo' in the same way
+as `"momo/sass/src"`.
 
 ## Slicing
 

--- a/test/index.html
+++ b/test/index.html
@@ -18,10 +18,10 @@
         enabled: true,
         paths: {
             'BasiGX': '../packages/remote/BasiGX/src',
-            'ShogunClient': '../app',
-            'ShogunClient.util': '../app/util',
-            'ShogunClient.view': '../app/view',
-            'ShogunClient.main': '../app/main'
+            'momo': '../app',
+            'momo.util': '../app/util',
+            'momo.view': '../app/view',
+            'momo.main': '../app/main'
         }
     });
     </script>

--- a/test/spec/Application.test.js
+++ b/test/spec/Application.test.js
@@ -1,9 +1,9 @@
-Ext.Loader.syncRequire(['ShogunClient.Application']);
+Ext.Loader.syncRequire(['momo.Application']);
 
-describe('ShogunClient.Application', function() {
+describe('momo.Application', function() {
     describe('Basics', function() {
         it('is defined', function() {
-            expect(ShogunClient.Application).to.not.be(undefined);
+            expect(momo.Application).to.not.be(undefined);
         });
     });
 });

--- a/test/spec/basics.test.js
+++ b/test/spec/basics.test.js
@@ -1,4 +1,4 @@
-describe('Basic requirements of ShogunClient', function() {
+describe('Basic requirements of momo', function() {
     describe('Libraries are loaded & available in testsuite', function() {
         describe('ExtJS', function() {
             it('is defined', function() {

--- a/test/spec/util/ApplicationContext.test.js
+++ b/test/spec/util/ApplicationContext.test.js
@@ -1,9 +1,9 @@
 /*eslint max-len: [0, 80, 4]*/
-Ext.Loader.syncRequire(['ShogunClient.util.ApplicationContext']);
+Ext.Loader.syncRequire(['momo.util.ApplicationContext']);
 
-describe('ShogunClient.util.ApplicationContext', function() {
+describe('momo.util.ApplicationContext', function() {
 
-    var clazz = ShogunClient.util.ApplicationContext;
+    var clazz = momo.util.ApplicationContext;
 
     describe('Basics', function() {
         it('is defined', function() {

--- a/test/spec/view/component/MapController.test.js
+++ b/test/spec/view/component/MapController.test.js
@@ -1,11 +1,11 @@
 /*eslint max-len: [0, 80, 4]*/
-Ext.Loader.syncRequire(['ShogunClient.view.component.MapController']);
+Ext.Loader.syncRequire(['momo.view.component.MapController']);
 
-describe('ShogunClient.view.component.MapController', function() {
+describe('momo.view.component.MapController', function() {
     var mapController;
 
     beforeEach(function() {
-        mapController = Ext.create('ShogunClient.view.component.MapController');
+        mapController = Ext.create('momo.view.component.MapController');
     });
 
     afterEach(function() {
@@ -14,10 +14,10 @@ describe('ShogunClient.view.component.MapController', function() {
 
     describe('Basics', function() {
         it('is defined', function() {
-            expect(ShogunClient.view.component.MapController).to.not.be(undefined);
+            expect(momo.view.component.MapController).to.not.be(undefined);
         });
         it('can be instantiated', function() {
-            expect(mapController).to.be.a(ShogunClient.view.component.MapController);
+            expect(mapController).to.be.a(momo.view.component.MapController);
         });
     });
 


### PR DESCRIPTION
This MR introduces the following changes:
- Get rid of wrong workspace (`ShogunClient`) in tests
- Small update of readme files to match the `momo` workspace
- `lib` folder will be ignored by `eslint`now
