### PR TITLE
Get map navigation buttons working with `momo-component-map`

### DIFF
--- a/app/view/component/MapController.js
+++ b/app/view/component/MapController.js
@@ -251,19 +251,21 @@ Ext.define('momo.view.component.MapController', {
 
     setRouting: function(){
         var mapComponentXType = 'momo-component-map';
+        var viewModel =
+            this.getView().up().down(mapComponentXType).getViewModel();
         var hash = BasiGX.util.Application.getRoute(mapComponentXType);
 
         // If the map moved without hitting a navigationhistorybutton,
         // the history starts new.
-        if(!this.getViewModel().get('clickedNav')){
-            this.getViewModel().set('currentMapStateIndex', null);
+        if(!viewModel.get('clickedNav')){
+            viewModel.set('currentMapStateIndex', null);
         }
         // Store new mapState unless the stepForward button was clicked.
-        if(this.getViewModel().get('clickedNav') !== 'stepForward'){
+        if(viewModel.get('clickedNav') !== 'stepForward'){
             this.storeRoute(hash);
         }
         // After storing the route reset the clickedNav value.
-        this.getViewModel().set('clickedNav', null);
+        viewModel.set('clickedNav', null);
         return hash;
     },
 

--- a/classic/src/view/button/StepBack.js
+++ b/classic/src/view/button/StepBack.js
@@ -55,8 +55,9 @@ Ext.define("momo.view.button.StepBack", {
     *
     */
     handler: function(){
-        var mainModel = this.up('momo-panel-mapcontainer').getViewModel();
-        var mainController = this.up('momo-panel-mapcontainer').getController();
+        var mapContainer = this.up('momo-panel-mapcontainer');
+        var mainModel = mapContainer.down('momo-component-map').getViewModel();
+        var mainController = mapContainer.getController();
         var mapStateHistory = mainModel.get('mapStateHistory');
         var currentMapStateIndex = mainModel.get('currentMapStateIndex');
         var newMapStateIndex;

--- a/classic/src/view/button/StepForward.js
+++ b/classic/src/view/button/StepForward.js
@@ -55,8 +55,9 @@ Ext.define("momo.view.button.StepForward", {
     *
     */
     handler: function(){
-        var mainModel = this.up('momo-panel-mapcontainer').getViewModel();
-        var mainController = this.up('momo-panel-mapcontainer').getController();
+        var mapContainer = this.up('momo-panel-mapcontainer');
+        var mainModel = mapContainer.down('momo-component-map').getViewModel();
+        var mainController = mapContainer.getController();
         var mapStateHistory = mainModel.get('mapStateHistory');
         var currentMapStateIndex = mainModel.get('currentMapStateIndex');
         var newMapStateIndex;

--- a/classic/src/view/panel/MapContainer.js
+++ b/classic/src/view/panel/MapContainer.js
@@ -13,37 +13,36 @@ Ext.define("momo.view.panel.MapContainer",{
 
     viewModel: 'component.map',
 
-    mapComponentConfig: {
-        xtype: 'momo-component-map'
-    },
-
-    overviewMapConfig: {
-        xtype: 'gx_overviewmap',
-        magnification: 10,
-        width: 400,
-        height: 150,
-        padding: 5,
-        cls: 'basigx-overview-map',
-        hidden: true,
-        layers: [
-            new ol.layer.Tile({
-                source: new ol.source.TileWMS({
-                    url: 'http://ows.terrestris.de/osm/service?',
-                    params: {
-                        LAYERS: 'OSM-WMS',
-                        TRANSPARENT: false,
-                        VERSION: '1.1.1'
-                    }
+    config: {
+        mapComponentConfig: {
+            xtype: 'momo-component-map'
+        },
+        overviewMapConfig: {
+            xtype: 'gx_overviewmap',
+            magnification: 10,
+            width: 400,
+            height: 150,
+            padding: 5,
+            cls: 'basigx-overview-map',
+            hidden: true,
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.TileWMS({
+                        url: 'http://ows.terrestris.de/osm/service?',
+                        params: {
+                            LAYERS: 'OSM-WMS',
+                            TRANSPARENT: false,
+                            VERSION: '1.1.1'
+                        }
+                    })
                 })
-            })
-        ]
+            ]
+        },
+        // we don't need menu container (yet)
+        menuConfig: null,
+        // we already have our own legend panel in west region
+        legendPanelConfig: null
     },
-
-    // we don't need menu container (yet)
-    menuConfig: null,
-
-    // we already have our own legend panel in west region
-    legendPanelConfig: null,
 
     listeners: {
         boxready: function(mapContainer){


### PR DESCRIPTION
Since we use our own `momo-component-map` component in frontend, some adjustments were needed to get map navigation buttons (`StepForward` and `StepBack`) working again.
