### PR TITLE
Adjust pathes to ol scripts 

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,14 @@
 
     <title>Momo Map-Client</title>
 
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
-    <script src="http://openlayers.org/en/master/build/ol-debug.js"></script>
+
+    <!-- ol3 debug sources -->
+    <!--<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.17.1/ol-debug.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.17.1/ol-debug.js"></script>-->
+
+    <!-- ol3 production sources (v3.17.1) -->
+    <link rel="stylesheet" type="text/css" href="../lib/ol3/css/ol.css">
+    <script src="../lib/ol3/build/ol.js"></script>
 
     <script type="text/javascript">
         var Ext = Ext || {}; // Ext namespace won't be defined yet...


### PR DESCRIPTION
Adjusted local pathes to ol js and css files.

Builded `ol.js` file can be created with the command `make check` inside of `lib/ol3` folder as described [here](https://github.com/openlayers/ol3/blob/master/CONTRIBUTING.md#the-check-build-target)

No review needed.
