### PR TITLE
Measurement tools panel

### DIFF
--- a/app/view/button/LoginLogoutController.js
+++ b/app/view/button/LoginLogoutController.js
@@ -1,3 +1,27 @@
+/* Copyright (c) 2016 terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * LoginLogoutController
+ *
+ * This controller will be used to manage the login/logout logic on the
+ * corresponding buttons click as well as displaying account name of the logged
+ * in user
+ *
+ * @class MoMo.client.view.button.LoginLogoutController
+ */
 Ext.define('MoMo.client.view.button.LoginLogoutController', {
     extend: 'Ext.app.ViewController',
 

--- a/app/view/button/LoginLogoutModel.js
+++ b/app/view/button/LoginLogoutModel.js
@@ -1,3 +1,25 @@
+/* Copyright (c) 2016 terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * LoginLogoutModel
+ *
+ * The view model for the login/logout button
+ *
+ * @class MoMo.client.view.button.LoginLogoutModel
+ */
 Ext.define('MoMo.client.view.button.LoginLogoutModel', {
     extend: 'Ext.app.ViewModel',
 

--- a/app/view/button/RbmaController.js
+++ b/app/view/button/RbmaController.js
@@ -1,3 +1,26 @@
+/* Copyright (c) 2016 terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * RbmaController
+ *
+ * This controller will be used to show/hide a RBMA modal window on click
+ * on the corresponding RBMA button
+ *
+ * @class MoMo.client.view.button.RbmaController
+ */
 Ext.define('MoMo.client.view.button.RbmaController', {
     extend: 'Ext.app.ViewController',
 

--- a/app/view/button/RbmaModel.js
+++ b/app/view/button/RbmaModel.js
@@ -1,3 +1,25 @@
+/* Copyright (c) 2016 terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * RbmaModel
+ *
+ * A View model for the RBMA module
+ *
+ * @class MoMo.client.view.button.RbmaModel
+ */
 Ext.define('MoMo.client.view.button.RbmaModel', {
     extend: 'Ext.app.ViewModel',
 

--- a/app/view/button/ShowMeasureToolsPanelController.js
+++ b/app/view/button/ShowMeasureToolsPanelController.js
@@ -1,0 +1,145 @@
+Ext.define('MoMo.client.view.button.ShowMeasureToolsPanelController', {
+    extend: 'Ext.app.ViewController',
+
+    requires: [
+    ],
+
+    alias: 'controller.button.showmeasuretoolspanel',
+
+    /**
+     * Placeholder for the measurement tools panel
+     */
+    btnPanel: null,
+
+    /**
+    *
+    */
+    onToggle: function(btn, pressed){
+        var me = this;
+        if (pressed){
+            me.showMeasureToolsPanel();
+        } else {
+            me.hideMeasureToolsPanel();
+            me.deactivateMeasureTools();
+        }
+    },
+
+    /**
+     * Creates a panel containing two buttons for distance and area measurements
+     * The position of the panel will be computed dynamically (s. method
+     * #computePosition below).
+     */
+    createMeasurementButtonsPanel: function() {
+
+        var me = this;
+
+        var parentBtn = me.getView().getEl();
+
+        var position = me.computePosition(parentBtn);
+
+        var btnPanel = Ext.create('Ext.panel.Panel', {
+            name: 'measurement-buttons-panel',
+            layout: {
+                type: 'hbox',
+                pack: 'right'
+            },
+            width: 100,
+            bodyStyle: {
+                background: 'transparent'
+            },
+            style: {
+                'top': position.top,
+                'right': position.right
+            },
+            defaults: {
+                style: {
+                    margin: '0 5px 0 5px'
+                },
+                xtype: 'basigx-button-measure',
+                toggleGroup: 'measure',
+                showMeasureInfoOnClickedPoints: true,
+                listeners: {
+                    afterrender: function(btn){
+                        btn.setBind({
+                            text: '{text}'
+                        });
+                    }
+                }
+            },
+            items: [{
+                measureType: 'line',
+                glyph: 'xf201@FontAwesome'
+            }, {
+                measureType: 'polygon',
+                glyph: 'xf1fe@FontAwesome'
+            }]
+        });
+
+        return btnPanel;
+    },
+
+    /**
+     * Shows a measurement tools panel on call button toggle.
+     */
+    showMeasureToolsPanel: function() {
+        var me = this;
+        if (!me.btnPanel) {
+            me.btnPanel = me.createMeasurementButtonsPanel();
+            var cont = Ext.ComponentQuery
+                .query('container[name="Map Container"]')[0];
+            cont.add(me.btnPanel);
+        } else {
+            me.btnPanel.show();
+        }
+    },
+
+    /**
+     * Computes position of the measurement tools panel depending on the
+     * dimensions and position of the parent button and the height of the
+     * application header if given.
+     */
+    computePosition: function(btn){
+        var header = Ext.ComponentQuery.query('panel[region=north]')[0],
+            hHeight = 0;
+
+        if (header) {
+            var hSplitter = header.splitter;
+            hHeight = header.getHeight();
+        }
+
+        var top =
+            btn.getClientRegion().top - hHeight - hSplitter.getHeight() + "px";
+        var right = btn.getWidth() + "px";
+
+        return {
+            top: top,
+            right: right
+        };
+    },
+
+    /**
+     * Hides a measurement tools panel on call button toggle.
+     */
+    hideMeasureToolsPanel: function() {
+        var me = this;
+        if (me.btnPanel) {
+            me.btnPanel.hide();
+        }
+    },
+
+    /**
+     * Deactivates possibly activated measure tools if parent button was
+     * untoggled and measurement tools panel was hidden.
+     */
+    deactivateMeasureTools: function (){
+        var me = this;
+        if (me.btnPanel) {
+            var measureBtns = me.btnPanel.query('button');
+            Ext.each(measureBtns, function(btn){
+                if (btn.pressed) {
+                    btn.toggle();
+                }
+            });
+        }
+    }
+});

--- a/app/view/button/ShowMeasureToolsPanelController.js
+++ b/app/view/button/ShowMeasureToolsPanelController.js
@@ -108,6 +108,7 @@ Ext.define('MoMo.client.view.button.ShowMeasureToolsPanelController', {
         var me = this;
         if (!me.btnPanel) {
             me.btnPanel = me.createMeasurementButtonsPanel();
+            // TODO find a better selector
             var cont = Ext.ComponentQuery
                 .query('container[name="Map Container"]')[0];
             cont.add(me.btnPanel);

--- a/app/view/button/ShowMeasureToolsPanelController.js
+++ b/app/view/button/ShowMeasureToolsPanelController.js
@@ -1,3 +1,26 @@
+/* Copyright (c) 2016 terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * ShowMeasureToolsPanelController
+ *
+ * This controller will be used to manage the measurement tools (distance
+ * and area) in the GIS applications
+ *
+ * @class ShowMeasureToolsPanelController
+ */
 Ext.define('MoMo.client.view.button.ShowMeasureToolsPanelController', {
     extend: 'Ext.app.ViewController',
 

--- a/app/view/button/ShowMeasureToolsPanelModel.js
+++ b/app/view/button/ShowMeasureToolsPanelModel.js
@@ -1,0 +1,10 @@
+Ext.define('MoMo.client.view.button.ShowMeasureToolsPanelModel', {
+    extend: 'Ext.app.ViewModel',
+
+    alias: 'viewmodel.button.showmeasuretoolspanel',
+
+    data: {
+        tooltip: 'Messwerkzeuge',
+        text: null
+    }
+});

--- a/app/view/button/ShowMeasureToolsPanelModel.js
+++ b/app/view/button/ShowMeasureToolsPanelModel.js
@@ -1,3 +1,25 @@
+/* Copyright (c) 2016 terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * ShowMeasureToolsPanelModel
+ *
+ * The view model for the measurement tools
+ *
+ * @class ShowMeasureToolsPanelModel
+ */
 Ext.define('MoMo.client.view.button.ShowMeasureToolsPanelModel', {
     extend: 'Ext.app.ViewModel',
 

--- a/app/view/button/TranslationController.js
+++ b/app/view/button/TranslationController.js
@@ -1,3 +1,25 @@
+/* Copyright (c) 2016 terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * TranslationController
+ *
+ * This controller implements the translation logic of the momo application
+ *
+ * @class MoMo.client.view.button.TranslationController
+ */
 Ext.define('MoMo.client.view.button.TranslationController', {
     extend: 'Ext.app.ViewController',
 

--- a/app/view/button/TranslationModel.js
+++ b/app/view/button/TranslationModel.js
@@ -1,3 +1,25 @@
+/* Copyright (c) 2016 terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * TranslationModel
+ *
+ * The view model for the translation tools
+ *
+ * @class MoMo.client.view.button.TranslationModel
+ */
 Ext.define('MoMo.client.view.button.TranslationModel', {
     extend: 'Ext.app.ViewModel',
 

--- a/classic/src/view/button/ShowMeasureToolsPanel.js
+++ b/classic/src/view/button/ShowMeasureToolsPanel.js
@@ -1,0 +1,54 @@
+/* Copyright (c) 2016 terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * ShowMeasureToolsPanel Button
+ *
+ * Button used to show and hide a panel with measure tools for the map
+ * (i.e. Distance and area measurements)
+ *
+ * @class ShowMeasureToolsPanel
+ */
+Ext.define("MoMo.client.view.button.ShowMeasureToolsPanel", {
+    extend: "Ext.button.Button",
+    xtype: 'momo-button-showmeasuretoolspanel',
+
+    requires: [
+        'Ext.app.ViewModel',
+        'BasiGX.util.Animate'
+    ],
+
+    controller: 'button.showmeasuretoolspanel',
+
+    viewModel: 'button.showmeasuretoolspanel',
+
+    bind: {
+        tooltip: '{tooltip}',
+        text: '{text}'
+    },
+
+    glyph: 'xf125@FontAwesome',
+
+    enableToggle: true,
+
+    listeners: {
+        toggle: 'onToggle'
+    },
+
+    initComponent: function () {
+        var me = this;
+        me.callParent();
+    }
+});

--- a/classic/src/view/button/ShowMeasureToolsPanel.js
+++ b/classic/src/view/button/ShowMeasureToolsPanel.js
@@ -45,10 +45,5 @@ Ext.define("MoMo.client.view.button.ShowMeasureToolsPanel", {
 
     listeners: {
         toggle: 'onToggle'
-    },
-
-    initComponent: function () {
-        var me = this;
-        me.callParent();
     }
 });


### PR DESCRIPTION
This PR introduces a measurement tools functionality. Via `momo-button-showmeasuretoolspanel` button a panel containing two tools to measure distances and areas can be shown. The logic of the single tools is inherited from [`BasiGX.view.button.Measure`](https://github.com/terrestris/BasiGX/blob/master/src/view/button/Measure.js) class

Corresponding PR in backend: https://github.com/terrestris/momo3-backend/pull/29

Please review @buehner @marcjansen 
