### PR TITLE
HSI tool

### DIFF
--- a/classic/src/plugin/Hover.js
+++ b/classic/src/plugin/Hover.js
@@ -1,0 +1,45 @@
+Ext.define('MoMo.client.plugin.Hover', {
+    extend: 'BasiGX.plugin.Hover',
+
+    alias: 'plugin.momo-client-hover',
+    pluginId: 'momo-client-hover',
+
+    /**
+    *
+    */
+    config: {
+        featureInfoEpsg: 'EPSG:32648'
+    },
+
+    /**
+     * Overrides the BasiGX method.
+     * Only layers with hoverable property set to true will be requested.
+     */
+    hoverLayerFilter: function(candidate) {
+        var hoverableProp = BasiGX.plugin.Hover.LAYER_HOVERABLE_PROPERTY_NAME;
+        if(candidate.get(hoverableProp)){
+            return true;
+        } else {
+            return false;
+        }
+    },
+
+    /**
+    * Overrides the BasiGX method.
+    * At the moment only the layer name will be shown as tooltip. If
+    * #BasiGX.plugin.Hover.LAYER_HOVERFIELD_PROPERTY_NAME is set the provided
+    * property name can be used for hovering. In this case the original BasiGX
+    * method or extension of this override can be used.
+    */
+    getToolTipHtml: function(layers){
+
+        var innerHtml = '';
+        Ext.each(layers, function(layer, index, allItems){
+            innerHtml += '<b>' + layer.get('name') + '</b>';
+            if(index + 1 !== allItems.length){
+                innerHtml += '<br />';
+            }
+        });
+        return innerHtml;
+    }
+});

--- a/classic/src/view/component/Map.js
+++ b/classic/src/view/component/Map.js
@@ -12,7 +12,9 @@ Ext.define('MoMo.client.view.component.Map', {
         'BasiGX.util.Map',
 
         'MoMo.client.view.component.MapController',
-        'MoMo.client.view.component.MapModel'
+        'MoMo.client.view.component.MapModel',
+
+        'MoMo.client.plugin.Hover'
     ],
 
     controller: 'component.map',
@@ -23,6 +25,14 @@ Ext.define('MoMo.client.view.component.Map', {
         guess: function(){
             return BasiGX.util.Map.getMapComponent('momo-component-map');
         }
+    },
+
+    plugins: [{
+        ptype: 'momo-client-hover'
+    }],
+
+    listeners: {
+        hoverfeaturesclick: 'onHoverFeatureClicked'
     },
 
     initComponent: function() {

--- a/index-template.html
+++ b/index-template.html
@@ -9,6 +9,9 @@
 
     <title>Momo Map-Client</title>
 
+    <!--  Proj4 2.3.6 -->
+    <script src="../lib/proj4/dist/proj4.js"></script>
+    <script src="../lib/proj4-defs/EPSG32648.js"></script>
 
     <!-- ol3 debug sources -->
     <!--<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.17.1/ol-debug.css">


### PR DESCRIPTION
This PR introduces a HSI tool based on [`BasiGX.plugin.Hover`](https://github.com/terrestris/BasiGX/blob/master/src/plugin/Hover.js) class with some adaptions (e.g. custom momo layer projection and tooltip configuration)

Also `proj4` library was embedded since `EPSG:32648` doesn't belong to native default projections.

Corresponding PR in backend: https://github.com/terrestris/momo3-backend/pull/32

Please review @buehner @marcjansen 
