### PR TITLE
Fixed broken print behaviour when opening / closing the window

### DIFF
--- a/app/view/button/PrintController.js
+++ b/app/view/button/PrintController.js
@@ -44,19 +44,26 @@ Ext.define('MoMo.client.view.button.PrintController', {
             if (!printWin) {
                 printWin = Ext.create('MoMo.view.window.PrintWindow', {
                     listeners: {
-                        'close': function(){
+                        'close': function() {
+                            btn.suspendEvents(false);
                             btn.toggle(false);
+                            btn.resumeEvents(true);
                         }
                     },
                     items: [{
                         xtype: 'momo-form-print',
-                        url: view.getPrintUrl() + '/print/'
+                        url: view.getPrintUrl() + '/print/',
+                        printExtentAlwaysCentered: false,
+                        printExtentMovable: true,
+                        printExtentScalable: true
                     }]
                 });
                 printWin.showAt(winX, winY);
             }
         } else {
-            printWin.destroy();
+            if (printWin) {
+                printWin.close();
+            }
         }
     }
 });

--- a/app/view/form/PrintController.js
+++ b/app/view/form/PrintController.js
@@ -287,18 +287,21 @@ Ext.define('MoMo.client.view.form.PrintController', {
         }
 
         if (!Ext.isEmpty(fl)){
-            return {
+            var el = {
                 xtype: xtype,
                 width: 400,
                 hidden: hidden,
                 name: attributeRec.get('name'),
                 childFieldKey: childFieldKey,
                 bind: {
-                    fieldLabel: fl,
-                    value: value
+                    fieldLabel: fl
                 },
                 allowBlank: true
             };
+            if (value) {
+                el.bind.value = value;
+            }
+            return el;
         }
     },
 

--- a/classic/src/view/form/Print.js
+++ b/classic/src/view/form/Print.js
@@ -23,6 +23,7 @@
  */
 Ext.define("MoMo.client.view.form.Print", {
     extend: "BasiGX.view.form.Print",
+
     xtype: "momo-form-print",
 
     layout: 'vbox',
@@ -56,6 +57,8 @@ Ext.define("MoMo.client.view.form.Print", {
         var appCombo = this.down('combo[name=appCombo]');
         appCombo.setValue("momo");
         appCombo.setHidden(true);
+        // hide the containing fieldset, which is empty now
+        appCombo.up().setHidden(true);
         this.provider = Ext.create('GeoExt.data.MapfishPrintProvider', {
             url: this.getUrl() + appCombo.getValue() + '/capabilities.json',
             listeners: {


### PR DESCRIPTION
never set a `value: undefined` on a components bind config in a form. Else, ExtJS will break when destroy method on father component is called... took me 90 min to find this