### PR TITLE
Fixing the broken Hoverfields

### DIFF
--- a/app/view/component/MapController.js
+++ b/app/view/component/MapController.js
@@ -218,7 +218,9 @@ Ext.define('MoMo.client.view.component.MapController', {
         var olLayer = new ol.layer['Tile']({
             name: mapLayer.name || 'UNNAMED LAYER',
             routingId: mapLayer.id,
-            hoverable: mapLayerAppearance.hoverable || false,
+            hoverable: mapLayerAppearance.hoverable || mapLayer.hoverable ||
+                false,
+            hoverTemplate: mapLayerAppearance.hoverTemplate,
             chartable: mapLayer.chartable || false,
             minResolution: mapLayerAppearance.minResolution || undefined,
             maxResolution: mapLayerAppearance.maxResolution || undefined,

--- a/classic/sass/src/view/component/Map.scss
+++ b/classic/sass/src/view/component/Map.scss
@@ -88,3 +88,12 @@
     left: auto !important;
     background-color: transparent !important;
 }
+
+div.feature-hover-popup {
+    background: rgba(255,255,255,0.8);
+    padding: 3px;
+    border: 2px solid #fff;
+    border-radius: 5px;
+    text-align: center;
+    color: #333;
+}

--- a/classic/src/plugin/Hover.js
+++ b/classic/src/plugin/Hover.js
@@ -30,20 +30,32 @@ Ext.define('MoMo.client.plugin.Hover', {
 
     /**
     * Overrides the BasiGX method.
-    * At the moment only the layer name will be shown as tooltip. If
-    * #BasiGX.plugin.Hover.LAYER_HOVERFIELD_PROPERTY_NAME is set the provided
-    * property name can be used for hovering. In this case the original BasiGX
-    * method or extension of this override can be used.
     */
-    getToolTipHtml: function(layers){
-
+    getToolTipHtml: function(layers, features) {
+        var me = this;
         var innerHtml = '';
         Ext.each(layers, function(layer, index, allItems){
             innerHtml += '<b>' + layer.get('name') + '</b>';
+            Ext.each(features, function(feat) {
+                if(feat && feat.get('layer') === layer){
+                    var tpl = layer.get("hoverTemplate");
+                    innerHtml += '<br />' + me.replaceAttributesTpl(tpl,
+                            feat.getProperties()) + '<br />';
+                }
+            });
             if(index + 1 !== allItems.length){
                 innerHtml += '<br />';
             }
         });
         return innerHtml;
+    },
+
+    /**
+     *
+     */
+    replaceAttributesTpl: function(tpl, feat){
+        var xtpl = new Ext.XTemplate(tpl);
+        var html = xtpl.apply(feat);
+        return html;
     }
 });


### PR DESCRIPTION
Makes the hoverfield configured in admin usable in client.
Related to https://github.com/terrestris/momo3-admin/pull/24