### PR TITLE
For all languages current mousepostion without overlap the labeltext

### DIFF
--- a/classic/src/view/panel/MapMetaInformation.js
+++ b/classic/src/view/panel/MapMetaInformation.js
@@ -41,7 +41,7 @@ Ext.define("MoMo.client.view.panel.MapMetaInformation", {
 
     collapsible: false,
 
-    width: 600,
+    width: 625,
 
     layout: {
         type: 'hbox'
@@ -74,7 +74,7 @@ Ext.define("MoMo.client.view.panel.MapMetaInformation", {
             }
         }, {
             xtype: 'displayfield',
-            width: 255,
+            width: 285,
             bind: {
                 fieldLabel: '{mousePositionLabel}'
             },


### PR DESCRIPTION
Now bigger width for the datafield and the panel.