### PR TITLE
Fixed display of coordinates in metadatawindow

### DIFF
--- a/classic/src/view/window/MetadataWindow.js
+++ b/classic/src/view/window/MetadataWindow.js
@@ -246,7 +246,7 @@ Ext.define('MoMo.client.view.window.MetadataWindow',{
             },
             items: [{
                 xtype: 'fieldcontainer',
-                layout: 'hbox',
+                layout: 'vbox',
                 defaults: {
                     xtype: 'displayfield',
                     labelWidth: 40,


### PR DESCRIPTION
This makes the coordinates readable by aligning them in vbox instead of hbox layout